### PR TITLE
remove branch renaming

### DIFF
--- a/lib_git.sh
+++ b/lib_git.sh
@@ -54,7 +54,7 @@ function git_sync () {
   git remote add target https://${gitlab_user}:${gitlab_token}@${dest_prefix}/${repo_name}.git
 
   # push to the local repo
-  git push target main:master
+  git push target
   if [ $? != 0 ]; then
     echo "[ERROR] failed to push to local repo: ${repo_name}"
     return 1


### PR DESCRIPTION
目前寫法是把 source branch `main` 推到 target branch `master`，這樣如果 source repo 的 default 不是 main 的話會出錯。
把它改成都用 source branch 預設的 branch 就好